### PR TITLE
Remove update DNS functions

### DIFF
--- a/local_cname.go
+++ b/local_cname.go
@@ -19,9 +19,6 @@ type LocalCNAME interface {
 	// Get a CNAME record by its domain.
 	Get(ctx context.Context, domain string) (*CNAMERecord, error)
 
-	// Update an existing CNAME record.
-	Update(ctx context.Context, domain string, IP string) (*CNAMERecord, error)
-
 	// Delete a CNAME record by its domain.
 	Delete(ctx context.Context, domain string) error
 }
@@ -140,25 +137,6 @@ func (cname localCNAME) Get(ctx context.Context, domain string) (*CNAMERecord, e
 	}
 
 	return nil, fmt.Errorf("%w: %s", ErrorLocalCNAMENotFound, domain)
-}
-
-// Update deletes and recreates a CNAME record
-func (cname localCNAME) Update(ctx context.Context, domain string, target string) (*CNAMERecord, error) {
-	_, err := cname.Get(ctx, domain)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := cname.Delete(ctx, domain); err != nil {
-		return nil, fmt.Errorf("failed to update %s", domain)
-	}
-
-	record, err := cname.Create(ctx, domain, target)
-	if err != nil {
-		return nil, fmt.Errorf("failed to recreate record during update process: %w", err)
-	}
-
-	return record, nil
 }
 
 // Delete removes a CNAME record by domain

--- a/local_cname_test.go
+++ b/local_cname_test.go
@@ -49,27 +49,6 @@ func TestLocalCNAME(t *testing.T) {
 		}, nil)
 	})
 
-	t.Run("Test update a CNAME record", func(t *testing.T) {
-		isAcceptance(t)
-
-		c := newTestClient()
-
-		domain := fmt.Sprintf("test.%s", randomID())
-
-		record, err := c.LocalCNAME.Create(context.Background(), domain, "domain.com")
-		require.NoError(t, err)
-		defer cleanupCNAME(t, c, record.Domain)
-
-		updated, err := c.LocalCNAME.Update(context.Background(), record.Domain, "domain-2.com")
-		require.NoError(t, err)
-
-		testAssertCNAME(t, c, updated, nil)
-		testAssertCNAME(t, c, &CNAMERecord{
-			Domain: record.Domain,
-			Target: "domain-2.com",
-		}, nil)
-	})
-
 	t.Run("Test delete a CNAME record", func(t *testing.T) {
 		isAcceptance(t)
 

--- a/local_dns.go
+++ b/local_dns.go
@@ -19,9 +19,6 @@ type LocalDNS interface {
 	// Get a DNS record by its domain.
 	Get(ctx context.Context, domain string) (*DNSRecord, error)
 
-	// Update an existing DNS record.
-	Update(ctx context.Context, domain string, IP string) (*DNSRecord, error)
-
 	// Delete a DNS record by its domain.
 	Delete(ctx context.Context, domain string) error
 }
@@ -140,25 +137,6 @@ func (dns localDNS) Get(ctx context.Context, domain string) (*DNSRecord, error) 
 	}
 
 	return nil, fmt.Errorf("%w: %s", ErrorLocalDNSNotFound, domain)
-}
-
-// Update deletes and recreates a custom DNS record
-func (dns localDNS) Update(ctx context.Context, domain string, IP string) (*DNSRecord, error) {
-	record, err := dns.Get(ctx, domain)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := dns.Delete(ctx, record.Domain); err != nil {
-		return nil, fmt.Errorf("failed to update %s", record.Domain)
-	}
-
-	updated, err := dns.Create(ctx, record.Domain, IP)
-	if err != nil {
-		return nil, fmt.Errorf("failed to recreate record during update process: %w", err)
-	}
-
-	return updated, nil
 }
 
 // Delete removes a custom DNS record

--- a/local_dns_test.go
+++ b/local_dns_test.go
@@ -49,27 +49,6 @@ func TestLocalDNS(t *testing.T) {
 		}, nil)
 	})
 
-	t.Run("Test update a DNS record", func(t *testing.T) {
-		isAcceptance(t)
-
-		c := newTestClient()
-
-		domain := fmt.Sprintf("test.%s", randomID())
-
-		record, err := c.LocalDNS.Create(context.Background(), domain, "127.0.0.1")
-		require.NoError(t, err)
-		defer cleanupDNS(t, c, record.Domain)
-
-		updated, err := c.LocalDNS.Update(context.Background(), record.Domain, "127.0.0.2")
-		require.NoError(t, err)
-
-		testAssertDNS(t, c, updated, nil)
-		testAssertDNS(t, c, &DNSRecord{
-			Domain: record.Domain,
-			IP:     "127.0.0.2",
-		}, nil)
-	})
-
 	t.Run("Test delete a DNS record", func(t *testing.T) {
 		isAcceptance(t)
 


### PR DESCRIPTION
Removes the LocalDNS.Update and LocalCNAME.Update methods. The Pi-hole API does not directly support updates, these implementations were a combination of create and delete. This is not something that should be supported here in the client without atomic support from the API itself. A consumer can choose to implement an update within their own project where they can weigh the risks on a project to project basis. 