### PR TITLE
rm setup terraform in acceptance tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -25,11 +25,6 @@ jobs:
         with:
           go-version: 1.17
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_wrapper: false
-
       - name: Start pihole
         run: docker-compose up -d
 


### PR DESCRIPTION
I noticed we had some terraform setup in the acc tests, probably copied from the pi-hole provider. not needed!