### PR TITLE
Ensure factory returns valid client

### DIFF
--- a/ad_blocker_status_test.go
+++ b/ad_blocker_status_test.go
@@ -12,7 +12,7 @@ func TestAdBlocker(t *testing.T) {
 	t.Run("enable ad blocker", func(t *testing.T) {
 		isAcceptance(t)
 
-		c := newTestClient()
+		c := newTestClient(t)
 		ctx := context.Background()
 
 		_, err := c.AdBlocker.Update(ctx, AdBlockerStatusOptions{
@@ -31,7 +31,7 @@ func TestAdBlocker(t *testing.T) {
 	t.Run("disable ad blocker", func(t *testing.T) {
 		isAcceptance(t)
 
-		c := newTestClient()
+		c := newTestClient(t)
 		ctx := context.Background()
 
 		_, err := c.AdBlocker.Update(ctx, AdBlockerStatusOptions{

--- a/client.go
+++ b/client.go
@@ -30,7 +30,7 @@ type Client struct {
 }
 
 // New returns a new Pi-hole client
-func New(config Config) *Client {
+func New(config Config) (*Client, error) {
 	baseURL := strings.TrimSuffix(config.BaseURL, "/")
 
 	baseURL = fmt.Sprintf("%s/admin/api.php", baseURL)
@@ -61,12 +61,16 @@ func New(config Config) *Client {
 	client.AdBlocker = &adBlocker{client: client}
 	client.Version = &version{client: client}
 
-	return client
+	if err := client.validate(); err != nil {
+		return nil, err
+	}
+
+	return client, nil
 }
 
 var ErrClientValidation = errors.New("invalid client configuration")
 
-func (c Client) Validate() error {
+func (c Client) validate() error {
 	if c.apiToken == "" {
 		return fmt.Errorf("%w: apiToken is empty", ErrClientValidation)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -15,34 +15,34 @@ func TestClientValidation(t *testing.T) {
 		isUnit(t)
 		t.Parallel()
 
-		c := New(Config{
+		_, err := New(Config{
 			BaseURL: "http://localhost:8080",
 		})
 
-		assert.ErrorIs(t, c.Validate(), ErrClientValidation)
+		assert.ErrorIs(t, err, ErrClientValidation)
 	})
 
 	t.Run("error on unset URL", func(t *testing.T) {
 		isUnit(t)
 		t.Parallel()
 
-		c := New(Config{
+		_, err := New(Config{
 			APIToken: "token",
 		})
 
-		assert.ErrorIs(t, c.Validate(), ErrClientValidation)
+		assert.ErrorIs(t, err, ErrClientValidation)
 	})
 
 	t.Run("no error on valid client config", func(t *testing.T) {
 		isUnit(t)
 		t.Parallel()
 
-		c := New(Config{
+		_, err := New(Config{
 			BaseURL:  "http://localhost:8080",
 			APIToken: "token",
 		})
 
-		assert.NoError(t, c.Validate())
+		assert.NoError(t, err)
 	})
 }
 
@@ -65,11 +65,15 @@ func accPreflghtCheck(t *testing.T) {
 	require.NotEmpty(t, os.Getenv("PIHOLE_API_TOKEN"), "PIHOLE_API_TOKEN must be set for acceptance tests")
 }
 
-func newTestClient() Client {
-	return *New(Config{
+func newTestClient(t *testing.T) *Client {
+	c, err := New(Config{
 		BaseURL:  os.Getenv("PIHOLE_URL"),
 		APIToken: os.Getenv("PIHOLE_API_TOKEN"),
 	})
+
+	require.NoError(t, err)
+
+	return c
 }
 
 func randomID() string {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   pihole:
     container_name: pihole
-    image: pihole/pihole:nightly
+    image: pihole/pihole:latest
     ports:
       - "8080:80/tcp"
     environment:

--- a/local_cname_test.go
+++ b/local_cname_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testAssertCNAME(t *testing.T, c Client, expected *CNAMERecord, assertErr error) {
+func testAssertCNAME(t *testing.T, c *Client, expected *CNAMERecord, assertErr error) {
 	actual, err := c.LocalCNAME.Get(context.TODO(), expected.Domain)
 	if assertErr != nil {
 		assert.ErrorAs(t, err, assertErr)
@@ -23,7 +23,7 @@ func testAssertCNAME(t *testing.T, c Client, expected *CNAMERecord, assertErr er
 	assert.Equal(t, expected.Target, actual.Target)
 }
 
-func cleanupCNAME(t *testing.T, c Client, domain string) {
+func cleanupCNAME(t *testing.T, c *Client, domain string) {
 	if err := c.LocalCNAME.Delete(context.TODO(), domain); err != nil {
 		log.Printf("Failed to clean up CNAME record: %s\n", domain)
 	}
@@ -33,7 +33,7 @@ func TestLocalCNAME(t *testing.T) {
 	t.Run("Test create a CNAME record", func(t *testing.T) {
 		isAcceptance(t)
 
-		c := newTestClient()
+		c := newTestClient(t)
 
 		domain := fmt.Sprintf("test.%s", randomID())
 
@@ -52,7 +52,7 @@ func TestLocalCNAME(t *testing.T) {
 	t.Run("Test delete a CNAME record", func(t *testing.T) {
 		isAcceptance(t)
 
-		c := newTestClient()
+		c := newTestClient(t)
 		ctx := context.Background()
 
 		domain := fmt.Sprintf("test.%s", randomID())

--- a/local_dns_test.go
+++ b/local_dns_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testAssertDNS(t *testing.T, c Client, expected *DNSRecord, assertErr error) {
+func testAssertDNS(t *testing.T, c *Client, expected *DNSRecord, assertErr error) {
 	actual, err := c.LocalDNS.Get(context.TODO(), expected.Domain)
 	if assertErr != nil {
 		assert.ErrorAs(t, err, assertErr)
@@ -23,7 +23,7 @@ func testAssertDNS(t *testing.T, c Client, expected *DNSRecord, assertErr error)
 	assert.Equal(t, expected.IP, actual.IP)
 }
 
-func cleanupDNS(t *testing.T, c Client, domain string) {
+func cleanupDNS(t *testing.T, c *Client, domain string) {
 	if err := c.LocalDNS.Delete(context.TODO(), domain); err != nil {
 		log.Printf("Failed to clean up domain record: %s\n", domain)
 	}
@@ -33,7 +33,7 @@ func TestLocalDNS(t *testing.T) {
 	t.Run("Test create a DNS record", func(t *testing.T) {
 		isAcceptance(t)
 
-		c := newTestClient()
+		c := newTestClient(t)
 
 		domain := fmt.Sprintf("test.%s", randomID())
 
@@ -52,7 +52,7 @@ func TestLocalDNS(t *testing.T) {
 	t.Run("Test delete a DNS record", func(t *testing.T) {
 		isAcceptance(t)
 
-		c := newTestClient()
+		c := newTestClient(t)
 		ctx := context.Background()
 
 		domain := fmt.Sprintf("test.%s", randomID())

--- a/version_test.go
+++ b/version_test.go
@@ -12,7 +12,7 @@ func TestVersion(t *testing.T) {
 	t.Run("Fetch versions", func(t *testing.T) {
 		isAcceptance(t)
 
-		c := newTestClient()
+		c := newTestClient(t)
 
 		versions, err := c.Version.Get(context.Background())
 		require.NoError(t, err)


### PR DESCRIPTION
Ensures that the client returned from client New factory is valid. No reason to put this extra call on the calling side. 