### PR TITLE
feat: Add Logout and dogfood in acceptance cleanup

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,12 +1,18 @@
 default: test
 
-.PHONY: testall test lint docs
+.PHONY: testall test lint docs acceptance
 
 test:
 	go test ./...
 
 acceptance:
-	TEST_ACC=1 go test ./...
+	TEST_ACC=1 go test -race -v ./...
 
 lint:
 	golangci-lint run ./...
+
+fmt:
+	go fmt ./...
+
+vet:
+	go vet ./...	

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package pihole
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"os"
@@ -62,4 +63,10 @@ func randomID() string {
 	}
 
 	return fmt.Sprintf("%X", b)
+}
+
+func cleanupTestClient(c *Client) {
+	if err := c.SessionAPI.Logout(context.TODO()); err != nil {
+		fmt.Printf("failed to clean up client after acceptance test: %s\n", err)
+	}
 }

--- a/local_cname_test.go
+++ b/local_cname_test.go
@@ -34,6 +34,7 @@ func TestLocalCNAME(t *testing.T) {
 		isAcceptance(t)
 
 		c := newTestClient(t)
+		defer cleanupTestClient(c)
 
 		domain := fmt.Sprintf("test.%s", randomID())
 
@@ -53,6 +54,8 @@ func TestLocalCNAME(t *testing.T) {
 		isAcceptance(t)
 
 		c := newTestClient(t)
+		defer cleanupTestClient(c)
+
 		ctx := context.Background()
 
 		domain := fmt.Sprintf("test.%s", randomID())

--- a/local_dns_test.go
+++ b/local_dns_test.go
@@ -34,6 +34,7 @@ func TestLocalDNS(t *testing.T) {
 		isAcceptance(t)
 
 		c := newTestClient(t)
+		defer cleanupTestClient(c)
 
 		domain := fmt.Sprintf("test.%s", randomID())
 
@@ -53,6 +54,8 @@ func TestLocalDNS(t *testing.T) {
 		isAcceptance(t)
 
 		c := newTestClient(t)
+		defer cleanupTestClient(c)
+
 		ctx := context.Background()
 
 		domain := fmt.Sprintf("test.%s", randomID())

--- a/session_test.go
+++ b/session_test.go
@@ -22,11 +22,42 @@ func TestSessionLogin(t *testing.T) {
 			isAcceptance(t)
 
 			c := newTestClient(t)
+			defer cleanupTestClient(c)
 
 			_, err := c.SessionAPI.Login(context.TODO())
 			require.NoError(t, err)
 
 			assert.NotEmpty(t, c.auth.sid)
+		})
+	}
+}
+
+func TestSessionLogout(t *testing.T) {
+	tcs := []struct {
+		name string
+	}{
+		{
+			name: "Logout SID on the client",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			isAcceptance(t)
+
+			c := newTestClient(t)
+
+			_, err := c.SessionAPI.Login(ctx)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, c.auth.sid)
+
+			err = c.SessionAPI.Logout(ctx)
+			require.NoError(t, err)
+
+			assert.Empty(t, c.auth.sid)
 		})
 	}
 }


### PR DESCRIPTION
Adds Logout functionality which we can hopefully use to not flood the API sessions in the Terraform provider. This seems to work well enough, after implementing the cleanup calls the pihole logs read 0 sessions in the DB

```pihole  | 2025-05-20 03:07:10.222 UTC [183M] INFO: Restored 0 API sessions from the database```

vs before

```pihole  | 2025-05-20 03:00:11.767 UTC [183M] INFO: Restored 11 API sessions from the database```